### PR TITLE
feat: 공통 응답 DTO 구현, 코드 수정, 사용자(Users) 엔드포인트 변경

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,6 @@
-JWTSECRET=ikDshiCLtsLQ66fiZMyr9qjS1NVNbWpz
+# jwt key
+JWT_SECRET=ikDshiCLtsLQ66fiZMyr9qjS1NVNbWpz
+
+# mongodb
+MONGO_URL=mongodb+srv://team13:0000@cluster0.8ii4h.mongodb.net/myFirstDatabase?retryWrites=true&w=majority
+MONGO_DATABASE=team13

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,14 +3,19 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 import { Users } from "./domain/entities/users.entity";
 import { UserModule } from "./domain/user/user.module";
 import { AuthModule } from "./domain/auth/auth.module";
+import { ConfigModule } from "@nestjs/config";
 
 @Module({
 	imports: [
+		ConfigModule.forRoot({
+			envFilePath: [".env"],
+			isGlobal: true
+		}),
 		TypeOrmModule.forRoot({
 			type: "mongodb",
-			url: "mongodb+srv://team13:0000@cluster0.8ii4h.mongodb.net/myFirstDatabase?retryWrites=true&w=majority",
+			url: process.env.MONGO_URL,
 			port: 27017,
-			database: "team13",
+			database: process.env.MONGO_DATABASE,
 			useNewUrlParser: true,
 			useUnifiedTopology: true,
 			entities: [Users]

--- a/src/domain/auth/auth.jwtStrategy.ts
+++ b/src/domain/auth/auth.jwtStrategy.ts
@@ -6,7 +6,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 		super({
 			jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
 			ignoreExpiration: false,
-			secretOrKey: "ikDshiCLtsLQ66fiZMyr9qjS1NVNbWpz"
+			secretOrKey: process.env.JWT_SECRET
 		});
 	}
 

--- a/src/domain/auth/auth.localStrategy.ts
+++ b/src/domain/auth/auth.localStrategy.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { PassportStrategy } from "@nestjs/passport";
 import { Strategy } from "passport-local";
+import { Users } from "../entities/users.entity";
 import { AuthService } from "./auth.service";
 
 @Injectable()
@@ -9,7 +10,7 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
 		super({ usernameField: "userId" });
 	}
 
-	async validate(userId: string, password: string) {
+	async validate(userId: string, password: string): Promise<Users> {
 		const user = this.authService.validateUser(userId, password);
 
 		if (!user) {

--- a/src/domain/auth/auth.module.ts
+++ b/src/domain/auth/auth.module.ts
@@ -1,4 +1,5 @@
 import { Module } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
 import { JwtModule } from "@nestjs/jwt";
 import { PassportModule } from "@nestjs/passport";
 import { TypeOrmModule } from "@nestjs/typeorm";
@@ -9,10 +10,14 @@ import { AuthService } from "./auth.service";
 
 @Module({
 	imports: [
+		ConfigModule.forRoot({
+			envFilePath: [".env"],
+			isGlobal: true
+		}),
 		PassportModule,
 		TypeOrmModule.forFeature([Users]),
 		JwtModule.register({
-			secret: "ikDshiCLtsLQ66fiZMyr9qjS1NVNbWpz",
+			secret: process.env.JWT_SECRET,
 			signOptions: { expiresIn: "1D" }
 		})
 	],

--- a/src/domain/auth/auth.service.ts
+++ b/src/domain/auth/auth.service.ts
@@ -13,7 +13,7 @@ export class AuthService {
 		private jwtService: JwtService
 	) {}
 
-	async validateUser(userId: string, password: string) {
+	async validateUser(userId: string, password: string): Promise<Users> {
 		const user = await this.usersRepository.findOne({
 			userId: userId
 		});
@@ -28,8 +28,8 @@ export class AuthService {
 		return user;
 	}
 
-	makeToken(user: Users) {
+	makeToken(user: Users): string {
 		const payload = { userId: user.userId, userName: user.userName };
-		return { token: this.jwtService.sign(payload) };
+		return this.jwtService.sign(payload);
 	}
 }

--- a/src/domain/global/common/CommonResponse.ts
+++ b/src/domain/global/common/CommonResponse.ts
@@ -1,0 +1,5 @@
+export class CommonResponse {
+	protected success: boolean;
+	protected statusCode: number;
+	protected message: string;
+}

--- a/src/domain/global/common/SuccessCode.ts
+++ b/src/domain/global/common/SuccessCode.ts
@@ -1,0 +1,21 @@
+export class SuccessCode {
+	private statusCode: number;
+	private message: string;
+
+	constructor(statusCode: number, message: string) {
+		this.statusCode = statusCode;
+		this.message = message;
+	}
+
+	getMessage(): string {
+		return this.message;
+	}
+
+	getStatusCode(): number {
+		return this.statusCode;
+	}
+
+	public static createUser() {
+		return new SuccessCode(201, "회원가입에 성공했습니다.");
+	}
+}

--- a/src/domain/global/common/SuccessResponse.ts
+++ b/src/domain/global/common/SuccessResponse.ts
@@ -1,0 +1,15 @@
+import { CommonResponse } from "./CommonResponse";
+import { SuccessCode } from "./SuccessCode";
+
+export class SuccessResponse extends CommonResponse {
+	constructor(successCode: SuccessCode) {
+		super();
+		this.success = true;
+		this.statusCode = successCode.getStatusCode();
+		this.message = successCode.getMessage();
+	}
+
+	public static response(successCode: SuccessCode) {
+		return new SuccessResponse(successCode);
+	}
+}

--- a/src/domain/user/dto/userResponse.dto.ts
+++ b/src/domain/user/dto/userResponse.dto.ts
@@ -1,0 +1,18 @@
+import { SuccessResponse } from "src/domain/global/common/SuccessResponse";
+import { SuccessCode } from "src/domain/global/common/SuccessCode";
+
+export class UserResponse extends SuccessResponse {
+	private token: string;
+
+	constructor(successCode: SuccessCode, data: string) {
+		super(successCode);
+		this.success = true;
+		this.statusCode = successCode.getStatusCode();
+		this.message = successCode.getMessage();
+		this.token = data;
+	}
+
+	public static return(successCode: SuccessCode, data: string) {
+		return new UserResponse(successCode, data);
+	}
+}

--- a/src/domain/user/user.controller.spec.ts
+++ b/src/domain/user/user.controller.spec.ts
@@ -1,18 +1,18 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { UserController } from './user.controller';
+import { Test, TestingModule } from "@nestjs/testing";
+import { UserController } from "./user.controller";
 
-describe('UserController', () => {
-  let controller: UserController;
+describe("UserController", () => {
+	let controller: UserController;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      controllers: [UserController],
-    }).compile();
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			controllers: [UserController]
+		}).compile();
 
-    controller = module.get<UserController>(UserController);
-  });
+		controller = module.get<UserController>(UserController);
+	});
 
-  it('should be defined', () => {
-    expect(controller).toBeDefined();
-  });
+	it("should be defined", () => {
+		expect(controller).toBeDefined();
+	});
 });

--- a/src/domain/user/user.controller.ts
+++ b/src/domain/user/user.controller.ts
@@ -1,7 +1,11 @@
 import { Body, Controller, Post, Request, UseGuards } from "@nestjs/common";
+import { STATUS_CODES } from "http";
 import { AuthService } from "../auth/auth.service";
+import { JwtGuard } from "../auth/guards/jwtGuard.guard";
 import { LocalAuthGuard } from "../auth/guards/localAuthGuard.guard";
+import { SuccessCode } from "../global/common/SuccessCode";
 import { CreateUserDto } from "./dto/createUser.dto";
+import { UserResponse } from "./dto/UserResponse.dto";
 import { UserService } from "./user.service";
 
 @Controller()
@@ -11,14 +15,20 @@ export class UserController {
 		private authService: AuthService
 	) {}
 
-	@Post("user")
-	async signUp(@Body() createUserDto: CreateUserDto) {
-		return await this.userService.create(createUserDto);
+	@Post("signup")
+	async signUp(@Body() createUserDto: CreateUserDto): Promise<UserResponse> {
+		return new UserResponse(
+			SuccessCode.createUser(),
+			await this.userService.create(createUserDto)
+		);
 	}
 
 	@UseGuards(LocalAuthGuard)
 	@Post("signin")
 	async login(@Request() req) {
-		return await this.authService.makeToken(req.user);
+		return new UserResponse(
+			SuccessCode.createUser(),
+			this.authService.makeToken(req.user)
+		);
 	}
 }

--- a/src/domain/user/user.service.spec.ts
+++ b/src/domain/user/user.service.spec.ts
@@ -1,18 +1,18 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { UserService } from './user.service';
+import { Test, TestingModule } from "@nestjs/testing";
+import { UserService } from "./user.service";
 
-describe('UserService', () => {
-  let service: UserService;
+describe("UserService", () => {
+	let service: UserService;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [UserService],
-    }).compile();
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [UserService]
+		}).compile();
 
-    service = module.get<UserService>(UserService);
-  });
+		service = module.get<UserService>(UserService);
+	});
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
-  });
+	it("should be defined", () => {
+		expect(service).toBeDefined();
+	});
 });

--- a/src/domain/user/user.service.ts
+++ b/src/domain/user/user.service.ts
@@ -25,6 +25,6 @@ export class UserService {
 		users.userName = createUserDto.userName;
 
 		await this.usersRepository.save(users);
-		return await this.authService.makeToken(users);
+		return this.authService.makeToken(users);
 	}
 }


### PR DESCRIPTION
**1. 공통 응답 DTO 구현**
모든 controller에서 공통적인 응답을 반환하기 위해 응답 기본형식을 갖춘
CommonResponse를 구현하였으며, 이를 상속받아 각 domain에서 반환 DTO를 선언
할 수 있게 하였습니다.

● CommonResponse 추가
● SuccessResponse 추가
● userResponse 추가

**2. 코드 수정**
인증 및 인가 부분의 코드를 일부 수정하였습니다.

● makeToken 반환시 "token: " 필드를 빼버리고 바로 token값을 반환
● 각 메소드의 반환 타입 선언

**3. 사용자 엔드포인트 변경**
사용자 엔드포인트가 변경되었습니다.

● 회원가입(user -> signup)
● 로그인(user -> signin)

**4. env 파일 설정**
env 파일을 통해 jwt key값과 db관련 설정을 할 수 있게 하였습니다.