### PR TITLE
Fix: MongoDB에 맞춰 entity 수정

### DIFF
--- a/src/domain/entities/boards.entity.ts
+++ b/src/domain/entities/boards.entity.ts
@@ -22,6 +22,12 @@ export class Boards {
 	boardId!: number;
 
 	@Column({ type: "varchar" })
+	userId!: string;
+
+	@Column({ type: "number" })
+	categoryCode!: number;
+
+	@Column({ type: "varchar" })
 	title!: string;
 
 	@Column({ type: "varchar" })
@@ -29,23 +35,6 @@ export class Boards {
 
 	@Column({ type: "varchar" })
 	readUser!: object;
-
-	@OneToMany(() => Comments, (comments) => comments.boards, {
-		onDelete: "CASCADE"
-	})
-	comments?: Comment[];
-
-	@ManyToOne(() => Users, (users) => users.boards, { lazy: true })
-	@JoinColumn([{ name: "userId", referencedColumnName: "userId" }])
-	users: Users;
-
-	@ManyToOne(() => CategoryCode, (categoryCode) => categoryCode.boards, {
-		lazy: true
-	})
-	@JoinColumn([
-		{ name: "categoryCode", referencedColumnName: "categoryCode" }
-	])
-	categoryCode: CategoryCode;
 
 	@CreateDateColumn({ type: "datetime" })
 	createdDt: Date;

--- a/src/domain/entities/categoryCode.entity.ts
+++ b/src/domain/entities/categoryCode.entity.ts
@@ -9,7 +9,7 @@ import {
 } from "typeorm";
 import { Boards } from "./boards.entity";
 
-@Entity("category_code")
+@Entity("categorycodes")
 export class CategoryCode {
 	@ObjectIdColumn({ type: "varchar" })
 	id!: ObjectID;
@@ -19,9 +19,6 @@ export class CategoryCode {
 
 	@Column({ type: "varchar" })
 	categoryName: string;
-
-	@OneToMany((type) => Boards, (boards) => boards.categoryCode)
-	boards: Boards[];
 
 	@CreateDateColumn({ type: "datetime" })
 	createdDt: Date;

--- a/src/domain/entities/comments.entity.ts
+++ b/src/domain/entities/comments.entity.ts
@@ -20,25 +20,20 @@ export class Comments {
 	@Column({ type: "number" })
 	commentId: number;
 
-	@Column({ type: "int" })
+	@Column({ type: "varchar" })
+	userId!: string;
+
+	@Column({ type: "number" })
+	boardId!: number;
+
+	@Column({ type: "number" })
+	parentId!: number;
+
+	@Column({ type: "number" })
 	depth!: number;
 
 	@Column({ type: "varchar" })
 	contents!: string;
-
-	@ManyToOne(() => Users, (users) => users.comments, { lazy: true })
-	@JoinColumn([{ name: "userId", referencedColumnName: "userId" }])
-	users: Users;
-
-	@ManyToOne(() => Boards, (boards) => boards.comments, { lazy: true })
-	@JoinColumn([{ name: "boardId", referencedColumnName: "boardId" }])
-	boards: Boards;
-
-	@ManyToOne(() => Comments, (comments) => comments.childId)
-	@JoinColumn([{ name: "parentId", referencedColumnName: "commentId" }])
-	parentId!: number;
-	@OneToMany(() => Comments, (comments) => comments.parentId)
-	childId!: number;
 
 	@CreateDateColumn({ type: "datetime" })
 	createdDt: Date;

--- a/src/domain/entities/users.entity.ts
+++ b/src/domain/entities/users.entity.ts
@@ -24,16 +24,6 @@ export class Users {
 	@Column({ type: "varchar" })
 	userName!: string;
 
-	@OneToMany(() => Boards, (boards) => boards.users, {
-		onDelete: "CASCADE"
-	})
-	boards?: Boards[];
-
-	@OneToMany(() => Comments, (comments) => comments.users, {
-		onDelete: "CASCADE"
-	})
-	comments?: Comment[];
-
 	@CreateDateColumn({ type: "datetime" })
 	createdDt: Date;
 


### PR DESCRIPTION
기존에 one to many, many to one 관계를 맺는 설정은 MongoDB에 의도치 않은
컬럼을 만들어내는 결과를 가져왔습니다. 따라서 관계 설정을 전부 빼버리고 컬럼
으로 만든 다음에, 값을 설정해서 넣기로 하였습니다.